### PR TITLE
create and populate server and simulator lists and compare both then …

### DIFF
--- a/PilotClient/App.config
+++ b/PilotClient/App.config
@@ -1,6 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
+    <configSections>
+        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
+            <section name="PilotClient.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
+        </sectionGroup>
+    </configSections>
     <startup useLegacyV2RuntimeActivationPolicy="true"> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
     </startup>
+    <userSettings>
+        <PilotClient.Properties.Settings>
+            <setting name="SimulatorPath" serializeAs="String">
+                <value />
+            </setting>
+        </PilotClient.Properties.Settings>
+    </userSettings>
 </configuration>

--- a/PilotClient/Properties/Settings.Designer.cs
+++ b/PilotClient/Properties/Settings.Designer.cs
@@ -8,22 +8,30 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace PilotClient.Properties
-{
-
-
+namespace PilotClient.Properties {
+    
+    
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "11.0.0.0")]
-    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase
-    {
-
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.7.0.0")]
+    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
+        
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
-
-        public static Settings Default
-        {
-            get
-            {
+        
+        public static Settings Default {
+            get {
                 return defaultInstance;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string SimulatorPath {
+            get {
+                return ((string)(this["SimulatorPath"]));
+            }
+            set {
+                this["SimulatorPath"] = value;
             }
         }
     }

--- a/PilotClient/Properties/Settings.settings
+++ b/PilotClient/Properties/Settings.settings
@@ -1,7 +1,9 @@
 ﻿<?xml version='1.0' encoding='utf-8'?>
-<SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)">
-  <Profiles>
-    <Profile Name="(Default)" />
-  </Profiles>
-  <Settings />
+<SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)" GeneratedClassNamespace="PilotClient.Properties" GeneratedClassName="Settings">
+  <Profiles />
+  <Settings>
+    <Setting Name="SimulatorPath" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
+  </Settings>
 </SettingsFile>

--- a/PilotClient/connectedExampleFrm.Designer.cs
+++ b/PilotClient/connectedExampleFrm.Designer.cs
@@ -32,6 +32,8 @@
             this.btnGetPositionAsync = new System.Windows.Forms.Button();
             this.btnGetXpndrAsync = new System.Windows.Forms.Button();
             this.btnConnect = new System.Windows.Forms.Button();
+            this.getSimulatorPathDialog = new System.Windows.Forms.FolderBrowserDialog();
+            this.btnSimPath = new System.Windows.Forms.Button();
             this.SuspendLayout();
             // 
             // txtLog
@@ -77,11 +79,27 @@
             this.btnConnect.UseVisualStyleBackColor = true;
             this.btnConnect.Click += new System.EventHandler(this.btnConnect_Click);
             // 
+            // getSimulatorPathDialog
+            // 
+            this.getSimulatorPathDialog.Description = "Get FSX/P3D Main Folder";
+            this.getSimulatorPathDialog.RootFolder = System.Environment.SpecialFolder.MyComputer;
+            // 
+            // btnSimPath
+            // 
+            this.btnSimPath.Location = new System.Drawing.Point(186, 528);
+            this.btnSimPath.Name = "btnSimPath";
+            this.btnSimPath.Size = new System.Drawing.Size(102, 23);
+            this.btnSimPath.TabIndex = 3;
+            this.btnSimPath.Text = "Change SimPath";
+            this.btnSimPath.UseVisualStyleBackColor = true;
+            this.btnSimPath.Click += new System.EventHandler(this.btnSimPath_Click);
+            // 
             // connectedExampleFrm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(518, 563);
+            this.Controls.Add(this.btnSimPath);
             this.Controls.Add(this.btnConnect);
             this.Controls.Add(this.btnGetXpndrAsync);
             this.Controls.Add(this.btnGetPositionAsync);
@@ -99,6 +117,8 @@
         private System.Windows.Forms.Button btnGetPositionAsync;
         private System.Windows.Forms.Button btnGetXpndrAsync;
         private System.Windows.Forms.Button btnConnect;
+        private System.Windows.Forms.FolderBrowserDialog getSimulatorPathDialog;
+        private System.Windows.Forms.Button btnSimPath;
     }
 }
 

--- a/PilotClient/connectedExampleFrm.cs
+++ b/PilotClient/connectedExampleFrm.cs
@@ -25,6 +25,9 @@ namespace PilotClient
             InitializeComponent();
 
             FSX.Player.Callsign = "TSZ213";
+
+            if(Properties.Settings.Default.SimulatorPath == "")
+                btnConnect.Enabled = false;
         }
 
         void displayText(string s)
@@ -83,7 +86,7 @@ namespace PilotClient
 
         private async void btnConnect_Click(object sender, EventArgs e)
         {
-            FSX.GetSimList();
+            FSX.GetSimList(Properties.Settings.Default.SimulatorPath);
 
             webSocket = new WebSocket(@"wss://fa-live.herokuapp.com/chat");
 
@@ -92,6 +95,17 @@ namespace PilotClient
             webSocket.Connect();
 
             await Send();
+        }
+
+        private void btnSimPath_Click(object sender, EventArgs e)
+        {
+            getSimulatorPathDialog.ShowDialog();
+
+            Properties.Settings.Default.SimulatorPath = getSimulatorPathDialog.SelectedPath;
+
+            Properties.Settings.Default.Save();
+
+            btnConnect.Enabled = true;
         }
     }
 }

--- a/PilotClient/connectedExampleFrm.cs
+++ b/PilotClient/connectedExampleFrm.cs
@@ -59,8 +59,6 @@ namespace PilotClient
             FSX.Aircraft traffic = JsonConvert.DeserializeObject<FSX.Aircraft>(
                 e.Data);
 
-            traffic.ModelName = "C172";
-
             FSX.Traffic.Set(traffic);
         }
 

--- a/PilotClient/connectedExampleFrm.cs
+++ b/PilotClient/connectedExampleFrm.cs
@@ -1,13 +1,8 @@
 ﻿using Newtonsoft.Json;
 using SimLib;
 using System;
-using System.Diagnostics;
-using WebSocketSharp;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
-using System.Net.Http;
-using System.Collections.Generic;
+using WebSocketSharp;
 
 namespace PilotClient
 {
@@ -64,7 +59,7 @@ namespace PilotClient
             FSX.Aircraft traffic = JsonConvert.DeserializeObject<FSX.Aircraft>(
                 e.Data);
 
-            traffic.ModelName = "Piper Pa-24-250 Comanche N6229P";
+            traffic.ModelName = "C172";
 
             FSX.Traffic.Set(traffic);
         }
@@ -90,6 +85,8 @@ namespace PilotClient
 
         private async void btnConnect_Click(object sender, EventArgs e)
         {
+            FSX.GetSimList();
+
             webSocket = new WebSocket(@"wss://fa-live.herokuapp.com/chat");
 
             webSocket.OnMessage += Receive;

--- a/PilotClient/connectedExampleFrm.resx
+++ b/PilotClient/connectedExampleFrm.resx
@@ -117,4 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="getSimulatorPathDialog.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>

--- a/SimLib/FSX.cs
+++ b/SimLib/FSX.cs
@@ -50,9 +50,14 @@ namespace SimLib
             }
         }
 
-        public static void GetSimList()
+        public static string SimulatorPath
+        { get; set; }
+
+        public static void GetSimList(string simPath)
         {
-            foreach (var directory in Directory.GetDirectories(@"C:\\Microsoft Flight Simulator X\\SimObjects\\Airplanes"))
+            SimulatorPath = simPath;
+
+            foreach (var directory in Directory.GetDirectories(simPath + "\\SimObjects\\Airplanes"))
             {
                 var dir = new DirectoryInfo(directory);
                 MyModels.Add(new MyModelMatching { ModelTitle = dir.Name });
@@ -108,7 +113,7 @@ namespace SimLib
                         try
                         {
                             ///compare all models on server and devolve true when installed
-                            if (File.ReadLines(String.Format("C:\\Microsoft Flight Simulator X\\SimObjects\\Airplanes\\{0}\\aircraft.cfg", simModels.ModelTitle)).Any(line => line.Contains(modelOnServer.ModelTitle)))
+                            if (File.ReadLines(String.Format("{0}\\SimObjects\\Airplanes\\{1}\\aircraft.cfg", SimulatorPath, simModels.ModelTitle)).Any(line => line.Contains(modelOnServer.ModelTitle)))
                                 Console.WriteLine("True");
                         }
                         catch (Exception ex)

--- a/SimLib/FSX.cs
+++ b/SimLib/FSX.cs
@@ -76,7 +76,7 @@ namespace SimLib
             public async void Create()
             {
                 ObjectId = await SimObjectType<AircraftState>.
-                    AICreateNonATCAircraft(ModelName, Callsign, State);
+                    AICreateNonATCAircraft(State.title, Callsign, State);
 
                 modelMatchingOnServer.Add(new ModelMatchingOnServer { ModelCallsign = "TSZ213", ModelTitle = State.title });
 


### PR DESCRIPTION
Produto final da minha Logica:
- cria lista dos models existentes no simulador
- cria lista dos models existentes no servidor
- compara se o Title dos models do servidor existe nos aircraft.cfg dos models instalados
- devolve na consola True quando o model no servidor é existente no simulador
- detecta automaticamente o model que o simulador está a utilizar
- Solicita e grava para utilizações futuras o caminho do simulador para posteriormente verificar os models instalados independentemente de ser FSX ou P3D