### PR TITLE
Recognize and get model from webserver. It works

### DIFF
--- a/PilotClient/App.config
+++ b/PilotClient/App.config
@@ -1,6 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
+    <configSections>
+        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
+            <section name="PilotClient.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
+        </sectionGroup>
+    </configSections>
     <startup useLegacyV2RuntimeActivationPolicy="true"> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
     </startup>
+    <userSettings>
+        <PilotClient.Properties.Settings>
+            <setting name="SimulatorPath" serializeAs="String">
+                <value />
+            </setting>
+        </PilotClient.Properties.Settings>
+    </userSettings>
 </configuration>

--- a/PilotClient/Properties/Settings.Designer.cs
+++ b/PilotClient/Properties/Settings.Designer.cs
@@ -8,22 +8,30 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace PilotClient.Properties
-{
-
-
+namespace PilotClient.Properties {
+    
+    
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "11.0.0.0")]
-    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase
-    {
-
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.7.0.0")]
+    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
+        
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
-
-        public static Settings Default
-        {
-            get
-            {
+        
+        public static Settings Default {
+            get {
                 return defaultInstance;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string SimulatorPath {
+            get {
+                return ((string)(this["SimulatorPath"]));
+            }
+            set {
+                this["SimulatorPath"] = value;
             }
         }
     }

--- a/PilotClient/Properties/Settings.settings
+++ b/PilotClient/Properties/Settings.settings
@@ -1,7 +1,9 @@
 ﻿<?xml version='1.0' encoding='utf-8'?>
-<SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)">
-  <Profiles>
-    <Profile Name="(Default)" />
-  </Profiles>
-  <Settings />
+<SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)" GeneratedClassNamespace="PilotClient.Properties" GeneratedClassName="Settings">
+  <Profiles />
+  <Settings>
+    <Setting Name="SimulatorPath" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
+  </Settings>
 </SettingsFile>

--- a/PilotClient/connectedExampleFrm.Designer.cs
+++ b/PilotClient/connectedExampleFrm.Designer.cs
@@ -32,6 +32,8 @@
             this.btnGetPositionAsync = new System.Windows.Forms.Button();
             this.btnGetXpndrAsync = new System.Windows.Forms.Button();
             this.btnConnect = new System.Windows.Forms.Button();
+            this.btnSimPath = new System.Windows.Forms.Button();
+            this.getSimulatorPathDialog = new System.Windows.Forms.FolderBrowserDialog();
             this.SuspendLayout();
             // 
             // txtLog
@@ -77,11 +79,28 @@
             this.btnConnect.UseVisualStyleBackColor = true;
             this.btnConnect.Click += new System.EventHandler(this.btnConnect_Click);
             // 
+            // btnSimPath
+            // 
+            this.btnSimPath.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnSimPath.Location = new System.Drawing.Point(190, 528);
+            this.btnSimPath.Name = "btnSimPath";
+            this.btnSimPath.Size = new System.Drawing.Size(98, 23);
+            this.btnSimPath.TabIndex = 3;
+            this.btnSimPath.Text = "Change SimPath";
+            this.btnSimPath.UseVisualStyleBackColor = true;
+            this.btnSimPath.Click += new System.EventHandler(this.btnSimPath_Click);
+            // 
+            // getSimulatorPathDialog
+            // 
+            this.getSimulatorPathDialog.Description = "Select FSX/P3D Main Folder";
+            this.getSimulatorPathDialog.RootFolder = System.Environment.SpecialFolder.MyComputer;
+            // 
             // connectedExampleFrm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(518, 563);
+            this.Controls.Add(this.btnSimPath);
             this.Controls.Add(this.btnConnect);
             this.Controls.Add(this.btnGetXpndrAsync);
             this.Controls.Add(this.btnGetPositionAsync);
@@ -99,6 +118,8 @@
         private System.Windows.Forms.Button btnGetPositionAsync;
         private System.Windows.Forms.Button btnGetXpndrAsync;
         private System.Windows.Forms.Button btnConnect;
+        private System.Windows.Forms.Button btnSimPath;
+        private System.Windows.Forms.FolderBrowserDialog getSimulatorPathDialog;
     }
 }
 

--- a/PilotClient/connectedExampleFrm.cs
+++ b/PilotClient/connectedExampleFrm.cs
@@ -64,7 +64,7 @@ namespace PilotClient
             FSX.Aircraft traffic = JsonConvert.DeserializeObject<FSX.Aircraft>(
                 e.Data);
 
-            traffic.ModelName = "C172 TSZ";
+            traffic.ModelName = "C172";
 
             FSX.Traffic.Set(traffic);
         }

--- a/PilotClient/connectedExampleFrm.cs
+++ b/PilotClient/connectedExampleFrm.cs
@@ -64,7 +64,7 @@ namespace PilotClient
             FSX.Aircraft traffic = JsonConvert.DeserializeObject<FSX.Aircraft>(
                 e.Data);
 
-            traffic.ModelName = "Piper Pa-24-250 Comanche N6229P";
+            traffic.ModelName = "C172 TSZ";
 
             FSX.Traffic.Set(traffic);
         }

--- a/PilotClient/connectedExampleFrm.cs
+++ b/PilotClient/connectedExampleFrm.cs
@@ -29,7 +29,10 @@ namespace PilotClient
         {
             InitializeComponent();
 
-            FSX.Player.Callsign = "TSZ213";
+            FSX.Player.Callsign = "TSZ212";
+
+            if (Properties.Settings.Default.SimulatorPath == "")
+                btnConnect.Enabled = false;
         }
 
         void displayText(string s)
@@ -90,7 +93,7 @@ namespace PilotClient
 
         private async void btnConnect_Click(object sender, EventArgs e)
         {
-            FSX.GetSimList(@"C:\Microsoft Flight Simulator X");
+            FSX.GetSimList(Properties.Settings.Default.SimulatorPath);
 
             webSocket = new WebSocket(@"wss://fa-live.herokuapp.com/chat");
 
@@ -99,6 +102,17 @@ namespace PilotClient
             webSocket.Connect();
 
             await Send();
+        }
+
+        private void btnSimPath_Click(object sender, EventArgs e)
+        {
+            getSimulatorPathDialog.ShowDialog();
+
+            Properties.Settings.Default.SimulatorPath = getSimulatorPathDialog.SelectedPath;
+
+            Properties.Settings.Default.Save();
+
+            btnConnect.Enabled = true;
         }
     }
 }

--- a/PilotClient/connectedExampleFrm.cs
+++ b/PilotClient/connectedExampleFrm.cs
@@ -90,6 +90,8 @@ namespace PilotClient
 
         private async void btnConnect_Click(object sender, EventArgs e)
         {
+            FSX.GetSimList(@"C:\Microsoft Flight Simulator X");
+
             webSocket = new WebSocket(@"wss://fa-live.herokuapp.com/chat");
 
             webSocket.OnMessage += Receive;

--- a/PilotClient/connectedExampleFrm.cs
+++ b/PilotClient/connectedExampleFrm.cs
@@ -29,7 +29,7 @@ namespace PilotClient
         {
             InitializeComponent();
 
-            FSX.Player.Callsign = "TSZ212";
+            FSX.Player.Callsign = "TSZ213";
 
             if (Properties.Settings.Default.SimulatorPath == "")
                 btnConnect.Enabled = false;
@@ -66,8 +66,6 @@ namespace PilotClient
         {
             FSX.Aircraft traffic = JsonConvert.DeserializeObject<FSX.Aircraft>(
                 e.Data);
-
-            traffic.ModelName = "C172";
 
             FSX.Traffic.Set(traffic);
         }

--- a/PilotClient/connectedExampleFrm.cs
+++ b/PilotClient/connectedExampleFrm.cs
@@ -29,7 +29,7 @@ namespace PilotClient
         {
             InitializeComponent();
 
-            FSX.Player.Callsign = "TSZ213";
+            FSX.Player.Callsign = "TSZ112";
 
             if (Properties.Settings.Default.SimulatorPath == "")
                 btnConnect.Enabled = false;

--- a/PilotClient/connectedExampleFrm.resx
+++ b/PilotClient/connectedExampleFrm.resx
@@ -117,4 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="getSimulatorPathDialog.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>

--- a/SimLib/FSX.cs
+++ b/SimLib/FSX.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.FlightSimulator.SimConnect;
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace SimLib
@@ -48,6 +50,28 @@ namespace SimLib
             }
         }
 
+        public static string SimulatorPath
+        { get; set; }
+
+        public static void GetSimList(string simPath)
+        {
+            SimulatorPath = simPath;
+
+            foreach (var directory in Directory.GetDirectories(simPath + "\\SimObjects\\Airplanes"))
+            {
+                var dir = new DirectoryInfo(directory);
+                MyModels.Add(new MyModelMatching { ModelTitle = dir.Name });
+            }
+        }
+
+        public static List<MyModelMatching> MyModels = new List<MyModelMatching>();
+
+        public class MyModelMatching
+        {
+            public string ModelTitle
+            { get; set; }
+        }
+
         public class Aircraft
         {
             public string Callsign
@@ -66,6 +90,23 @@ namespace SimLib
             {
                 ObjectId = await SimObjectType<AircraftState>.
                     AICreateNonATCAircraft(State.title, Callsign, State);
+
+                foreach (var simModels in MyModels)
+                {
+                    try
+                    {
+                        ///compare all models on server and devolve true when installed
+                        if (File.ReadLines(String.Format("{0}\\SimObjects\\Airplanes\\{1}\\aircraft.cfg", SimulatorPath, simModels.ModelTitle)).Any(line => line.Contains(State.title)))
+                        {
+                            Console.WriteLine(String.Format("{0} are installed with callsign {1}.", State.title, Callsign));
+
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+
+                    }
+                }
             }
 
             internal async Task<AircraftState> Read()

--- a/SimLib/FSX.cs
+++ b/SimLib/FSX.cs
@@ -91,22 +91,7 @@ namespace SimLib
                 ObjectId = await SimObjectType<AircraftState>.
                     AICreateNonATCAircraft(State.title, Callsign, State);
 
-                foreach (var simModels in MyModels)
-                {
-                    try
-                    {
-                        ///compare all models on server and devolve true when installed
-                        if (File.ReadLines(String.Format("{0}\\SimObjects\\Airplanes\\{1}\\aircraft.cfg", SimulatorPath, simModels.ModelTitle)).Any(line => line.Contains(State.title)))
-                        {
-                            Console.WriteLine(String.Format("{0} are installed with callsign {1}.", State.title, Callsign));
-
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-
-                    }
-                }
+                await VerifyInstalledModel();
             }
 
             internal async Task<AircraftState> Read()
@@ -123,6 +108,28 @@ namespace SimLib
 
                 await SimObjectType<AircraftState>.
                     SetDataOnSimObject((uint)ObjectId, State);
+            }
+
+            public async Task VerifyInstalledModel()
+            {
+                int trues = 0;
+
+                foreach (var simModels in MyModels)
+                {
+                    string[] allFiles = Directory.GetFiles(String.Format("{0}\\SimObjects\\Airplanes\\{1}", SimulatorPath, simModels.ModelTitle), "*.cfg");
+
+                    foreach (string file in allFiles)
+                    {
+                        string[] lines = File.ReadAllLines(file);
+                        string firstOccurrence = lines.FirstOrDefault(l => l.Contains(State.title));
+                        if (firstOccurrence != null)
+                        {
+                            Console.WriteLine(String.Format("{0} with callsign {1}", firstOccurrence, Callsign));
+
+                            trues = trues + 1;
+                        }
+                    }
+                }
             }
         }
     }

--- a/SimLib/FSX.cs
+++ b/SimLib/FSX.cs
@@ -130,6 +130,13 @@ namespace SimLib
                         }
                     }
                 }
+
+                if(trues == 0)
+                {
+                    //Get Sim Model
+                    Console.WriteLine(String.Format("Need Get Model {0}", State.title));
+                }
+             
             }
         }
     }

--- a/SimLib/FSX.cs
+++ b/SimLib/FSX.cs
@@ -65,7 +65,7 @@ namespace SimLib
             public async void Create()
             {
                 ObjectId = await SimObjectType<AircraftState>.
-                    AICreateNonATCAircraft(ModelName, Callsign, State);
+                    AICreateNonATCAircraft(State.title, Callsign, State);
             }
 
             internal async Task<AircraftState> Read()

--- a/SimLib/SimLib.csproj
+++ b/SimLib/SimLib.csproj
@@ -36,6 +36,8 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />


### PR DESCRIPTION
Para funcionar tens que adicionar uma pasta com o nome (NETWORK) à tua pasta SimObjects e a respectiva linha ao config do teu simulador.

O que faz:
- Reconhece e decide se necessita ou nao instalar model quando em falta através da verificação das pastas SimObjects e NETWORK, de todos os utilizadores conectados.

- Faz download do model e instala automaticamente na pasta NETWORK se necessario.

- Informa a necessidade de reiniciar inevitavelmente o simulador apos a instalação do model.

- Exibe o model quando instalado através das pastas Airplanes ou NETWORK.

TESTADO!!

Importante: Quando nao existe model o teu aviao vai sempre para cima do aviao do utilizador cujo ele nao reconhece o model, mesmo depois de instalado o teu aviao fica sempre a saltar para o avião do outro devido ao simulador ter que ser reiniciado para ele reconhecer o model instalado pelo cliente. 
Assim que reinicias o simulador tudo funciona normalmente e vez o Model do outro user certinho.
Fiz montes de testes com o Gonçalo e esta foi até agora a única forma funcional que encontrei de fazer isto acontecer. 

Deve-se corrigir depois o facto de ele criar primeiro o model para o utilizador mesmo quando não há model presente no simulador, o que garantidamente esta a fazer com que o aviao salte sempre para cima do utilizador cujo o model nao esta instalado, e  só depois verificar se há model ou nao no simulador mas não é motivo para o model nao aparecer antes de reiniciar o simulador pois também testei isso. Após a instalação de qualquer model e sempre necessária uma reinicialização do simulador.